### PR TITLE
Use Stream instead of *Serial/TwoWire

### DIFF
--- a/EasyTransfer/EasyTransfer.cpp
+++ b/EasyTransfer/EasyTransfer.cpp
@@ -4,10 +4,10 @@
 
 
 //Captures address and size of struct
-void EasyTransfer::begin(uint8_t * ptr, uint8_t length, HardwareSerial *theSerial){
+void EasyTransfer::begin(uint8_t * ptr, uint8_t length, Stream *theStream){
 	address = ptr;
 	size = length;
-	_serial = theSerial;
+	_stream = theStream;
 	
 	//dynamic creation of rx parsing buffer in RAM
 	rx_buffer = (uint8_t*) malloc(size);
@@ -16,14 +16,14 @@ void EasyTransfer::begin(uint8_t * ptr, uint8_t length, HardwareSerial *theSeria
 //Sends out struct in binary, with header, length info and checksum
 void EasyTransfer::sendData(){
   uint8_t CS = size;
-  _serial->write(0x06);
-  _serial->write(0x85);
-  _serial->write(size);
+  _stream->write(0x06);
+  _stream->write(0x85);
+  _stream->write(size);
   for(int i = 0; i<size; i++){
     CS^=*(address+i);
-    _serial->write(*(address+i));
+    _stream->write(*(address+i));
   }
-  _serial->write(CS);
+  _stream->write(CS);
 
 }
 
@@ -32,17 +32,17 @@ boolean EasyTransfer::receiveData(){
   //start off by looking for the header bytes. If they were already found in a previous call, skip it.
   if(rx_len == 0){
   //this size check may be redundant due to the size check below, but for now I'll leave it the way it is.
-    if(_serial->available() >= 3){
+    if(_stream->available() >= 3){
 	//this will block until a 0x06 is found or buffer size becomes less then 3.
-      while(_serial->read() != 0x06) {
+      while(_stream->read() != 0x06) {
 		//This will trash any preamble junk in the serial buffer
 		//but we need to make sure there is enough in the buffer to process while we trash the rest
 		//if the buffer becomes too empty, we will escape and try again on the next call
-		if(_serial->available() < 3)
+		if(_stream->available() < 3)
 			return false;
 		}
-      if (_serial->read() == 0x85){
-        rx_len = _serial->read();
+      if (_stream->read() == 0x85){
+        rx_len = _stream->read();
 		//make sure the binary structs on both Arduinos are the same size.
         if(rx_len != size){
           rx_len = 0;
@@ -54,8 +54,8 @@ boolean EasyTransfer::receiveData(){
   
   //we get here if we already found the header bytes, the struct size matched what we know, and now we are byte aligned.
   if(rx_len != 0){
-    while(_serial->available() && rx_array_inx <= rx_len){
-      rx_buffer[rx_array_inx++] = _serial->read();
+    while(_stream->available() && rx_array_inx <= rx_len){
+      rx_buffer[rx_array_inx++] = _stream->read();
     }
     
     if(rx_len == (rx_array_inx-1)){

--- a/EasyTransfer/EasyTransfer.h
+++ b/EasyTransfer/EasyTransfer.h
@@ -34,7 +34,7 @@ GNU General Public License for more details.
 #else
 #include "WProgram.h"
 #endif
-#include "HardwareSerial.h"
+#include "Stream.h"
 //#include <NewSoftSerial.h>
 #include <math.h>
 #include <stdio.h>
@@ -43,12 +43,12 @@ GNU General Public License for more details.
 
 class EasyTransfer {
 public:
-void begin(uint8_t *, uint8_t, HardwareSerial *theSerial);
+void begin(uint8_t *, uint8_t, Stream *theStream);
 //void begin(uint8_t *, uint8_t, NewSoftSerial *theSerial);
 void sendData();
 boolean receiveData();
 private:
-HardwareSerial *_serial;
+Stream *_stream;
 //NewSoftSerial *_serial;
 uint8_t * address;  //address of struct
 uint8_t size;       //size of struct


### PR DESCRIPTION
for newer arduinos,
- HardwareSerial
- NewSoftSerial
- TwoWire
- Serial_ (USB CDC)

are all subclass of the Stream abstract class.

and this way we automagically supports all transfer method which is
derived from Stream.
