### PR TITLE
Destructor, free the malloc

### DIFF
--- a/EasyTransfer/EasyTransfer.cpp
+++ b/EasyTransfer/EasyTransfer.cpp
@@ -85,3 +85,7 @@ boolean EasyTransfer::receiveData(){
   
   return false;
 }
+
+~EasyTransfer(){
+    free(rx_buffer);
+}

--- a/EasyTransfer/EasyTransfer.h
+++ b/EasyTransfer/EasyTransfer.h
@@ -47,6 +47,7 @@ void begin(uint8_t *, uint8_t, Stream *theStream);
 //void begin(uint8_t *, uint8_t, NewSoftSerial *theSerial);
 void sendData();
 boolean receiveData();
+~EasyTransfer();
 private:
 Stream *_stream;
 //NewSoftSerial *_serial;


### PR DESCRIPTION
Only use the destruct for free the malloc and avoid possible memory leaks !