### PR TITLE
Patch 1

### DIFF
--- a/EasyTransferI2C/EasyTransferI2C.h
+++ b/EasyTransferI2C/EasyTransferI2C.h
@@ -48,6 +48,7 @@ class EasyTransferI2C {
 public:
 void begin(uint8_t *, uint8_t, TwoWire *theSerial);
 void sendData(uint8_t address);
+void sendDataPerRequest(uint8_t address);
 boolean receiveData();
 private:
 TwoWire *_serial;


### PR DESCRIPTION
Added a function to be used in the slave-sender's request handler. I didn't modify your great cheksum system just crammed the message in a buffer and sent all in one write, because in the request handler only one write is allowed. Works great but it is limited to the buffer size this way. (Although that can be increased) Thanks for the great library.