### PR TITLE
Improve compatibility between boards with different processors

### DIFF
--- a/EasyTransfer/examples/EasyTransfer_2Way_wPot_Example/EasyTransfer_2Way_wPot_Example.pde
+++ b/EasyTransfer/examples/EasyTransfer_2Way_wPot_Example/EasyTransfer_2Way_wPot_Example.pde
@@ -1,8 +1,8 @@
 /*This is an example of the EasyTransfer Library 2way communications. 
 
-This sketch is for the Arduino with the servo attached to pin 9.
+The sketch is for the Arduino with a potentiometer attached to analog pin 0.
 
-The other Arduino has a potentiometer attached to analog pin 0.
+This other Arduino has the servo attached to pin 9.
 Both have a putton attached to pin 12 and output a status using the LED on pin 13.
 
 The idea is each arduino will read the status of the button attached to it, and send it
@@ -13,27 +13,26 @@ And the Arduino with the potentiometer will send it's value to the one with the 
 The servo will move to the position based on the potentiometer.
 */
 
-#include <Servo.h>
+
+
 #include <EasyTransfer.h>
 
 //create two objects
 EasyTransfer ETin, ETout; 
-//create servo
-Servo myservo;
+
 
 struct RECEIVE_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to receive
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int buttonstate;
-  int servoval;
+  int16_t buttonstate;
 };
 
 struct SEND_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to receive
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int buttonstate;
+  int16_t buttonstate;
+  int16_t servoval;
 };
-
 
 //give a name to the group of data
 RECEIVE_DATA_STRUCTURE rxdata;
@@ -51,35 +50,31 @@ void setup(){
   //enable pull-up
   digitalWrite(12, HIGH);
   
-  myservo.attach(9);
 }
 
 void loop(){
   
-  //first, lets read our button and store it in our data structure
+  //first, lets read our potentiometer and button and store it in our data structure
+  txdata.servoval = analogRead(0);
+  
   if(!digitalRead(12))
     txdata.buttonstate = HIGH;
   else
     txdata.buttonstate = LOW;
   
- //then we will go ahead and send that data out
+  //then we will go ahead and send that data out
   ETout.sendData();
   
  //there's a loop here so that we run the recieve function more often then the 
  //transmit function. This is important due to the slight differences in 
  //the clock speed of different Arduinos. If we didn't do this, messages 
  //would build up in the buffer and appear to cause a delay.
- 
   for(int i=0; i<5; i++){
     //remember, you could use an if() here to check for new data, this time it's not needed.
     ETin.receiveData();
     
-    //set our LED on or off based on what we received from the other Arduino
+    //set our LED on or off based on what we received from the other Arduino    
     digitalWrite(13, rxdata.buttonstate);
-    
-    //set our servo position based on what we received from the other Arduino
-    //we will also map the ADC value to a servo value
-    myservo.write(map(rxdata.servoval, 0, 1023, 0, 179));
     
     //delay
     delay(10);

--- a/EasyTransfer/examples/EasyTransfer_2Way_wPot_Example/EasyTransfer_2Way_wPot_Example.pde
+++ b/EasyTransfer/examples/EasyTransfer_2Way_wPot_Example/EasyTransfer_2Way_wPot_Example.pde
@@ -46,9 +46,8 @@ void setup(){
   ETout.begin(details(txdata), &Serial);
   
   pinMode(13, OUTPUT);  
-  pinMode(12, INPUT);
   //enable pull-up
-  digitalWrite(12, HIGH);
+  pinMode(12, INPUT_PULLUP);
   
 }
 

--- a/EasyTransfer/examples/EasyTransfer_2Way_wServo_Example/EasyTransfer_2Way_wServo_Example.pde
+++ b/EasyTransfer/examples/EasyTransfer_2Way_wServo_Example/EasyTransfer_2Way_wServo_Example.pde
@@ -1,8 +1,8 @@
 /*This is an example of the EasyTransfer Library 2way communications. 
 
-The sketch is for the Arduino with a potentiometer attached to analog pin 0.
+This sketch is for the Arduino with the servo attached to pin 9.
 
-This other Arduino has the servo attached to pin 9.
+The other Arduino has a potentiometer attached to analog pin 0.
 Both have a putton attached to pin 12 and output a status using the LED on pin 13.
 
 The idea is each arduino will read the status of the button attached to it, and send it
@@ -13,26 +13,27 @@ And the Arduino with the potentiometer will send it's value to the one with the 
 The servo will move to the position based on the potentiometer.
 */
 
-
-
+#include <Servo.h>
 #include <EasyTransfer.h>
 
 //create two objects
 EasyTransfer ETin, ETout; 
-
+//create servo
+Servo myservo;
 
 struct RECEIVE_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to receive
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int buttonstate;
+  int16_t buttonstate;
+  int16_t servoval;
 };
 
 struct SEND_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to receive
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int buttonstate;
-  int servoval;
+  int16_t buttonstate;
 };
+
 
 //give a name to the group of data
 RECEIVE_DATA_STRUCTURE rxdata;
@@ -50,31 +51,35 @@ void setup(){
   //enable pull-up
   digitalWrite(12, HIGH);
   
+  myservo.attach(9);
 }
 
 void loop(){
   
-  //first, lets read our potentiometer and button and store it in our data structure
-  txdata.servoval = analogRead(0);
-  
+  //first, lets read our button and store it in our data structure
   if(!digitalRead(12))
     txdata.buttonstate = HIGH;
   else
     txdata.buttonstate = LOW;
   
-  //then we will go ahead and send that data out
+ //then we will go ahead and send that data out
   ETout.sendData();
   
  //there's a loop here so that we run the recieve function more often then the 
  //transmit function. This is important due to the slight differences in 
  //the clock speed of different Arduinos. If we didn't do this, messages 
  //would build up in the buffer and appear to cause a delay.
+ 
   for(int i=0; i<5; i++){
     //remember, you could use an if() here to check for new data, this time it's not needed.
     ETin.receiveData();
     
-    //set our LED on or off based on what we received from the other Arduino    
+    //set our LED on or off based on what we received from the other Arduino
     digitalWrite(13, rxdata.buttonstate);
+    
+    //set our servo position based on what we received from the other Arduino
+    //we will also map the ADC value to a servo value
+    myservo.write(map(rxdata.servoval, 0, 1023, 0, 179));
     
     //delay
     delay(10);

--- a/EasyTransfer/examples/EasyTransfer_2Way_wServo_Example/EasyTransfer_2Way_wServo_Example.pde
+++ b/EasyTransfer/examples/EasyTransfer_2Way_wServo_Example/EasyTransfer_2Way_wServo_Example.pde
@@ -47,9 +47,8 @@ void setup(){
   ETout.begin(details(txdata), &Serial);
   
   pinMode(13, OUTPUT);  
-  pinMode(12, INPUT);
   //enable pull-up
-  digitalWrite(12, HIGH);
+  pinMode(12, INPUT_PULLUP);
   
   myservo.attach(9);
 }

--- a/EasyTransfer/examples/EasyTransfer_RX_Example/EasyTransfer_RX_Example.pde
+++ b/EasyTransfer/examples/EasyTransfer_RX_Example/EasyTransfer_RX_Example.pde
@@ -6,8 +6,8 @@ EasyTransfer ET;
 struct RECEIVE_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to receive
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int blinks;
-  int pause;
+  int16_t blinks;
+  int16_t pause;
 };
 
 //give a name to the group of data

--- a/EasyTransfer/examples/EasyTransfer_TX_Example/EasyTransfer_TX_Example.pde
+++ b/EasyTransfer/examples/EasyTransfer_TX_Example/EasyTransfer_TX_Example.pde
@@ -6,8 +6,8 @@ EasyTransfer ET;
 struct SEND_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to send
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int blinks;
-  int pause;
+  int16_t blinks;
+  int16_t pause;
 };
 
 //give a name to the group of data

--- a/EasyTransferI2C/examples/EasyTransfer_RX_Example/EasyTransfer_RX_Example.pde
+++ b/EasyTransferI2C/examples/EasyTransfer_RX_Example/EasyTransfer_RX_Example.pde
@@ -7,8 +7,8 @@ EasyTransferI2C ET;
 struct RECEIVE_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to receive
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int blinks;
-  int pause;
+  int16_t blinks;
+  int16_t pause;
 };
 
 //give a name to the group of data

--- a/EasyTransferI2C/examples/EasyTransfer_TX_Example/EasyTransfer_TX_Example.pde
+++ b/EasyTransferI2C/examples/EasyTransfer_TX_Example/EasyTransfer_TX_Example.pde
@@ -1,32 +1,26 @@
-#include <SoftEasyTransfer.h>
-
-/*   For Arduino 1.0 and newer, do this:   */
-#include <SoftwareSerial.h>
-SoftwareSerial mySerial(2, 3);
-
-/*   For Arduino 22 and older, do this:   */
-//#include <NewSoftSerial.h>
-//NewSoftSerial mySerial(2, 3);
-
-
+#include <Wire.h>
+#include <EasyTransferI2C.h>
 
 //create object
-SoftEasyTransfer ET; 
+EasyTransferI2C ET; 
 
 struct SEND_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to send
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int blinks;
-  int pause;
+  int16_t blinks;
+  int16_t pause;
 };
 
 //give a name to the group of data
 SEND_DATA_STRUCTURE mydata;
 
+//define slave i2c address
+#define I2C_SLAVE_ADDRESS 9
+
 void setup(){
-  mySerial.begin(9600);
-  //start the library, pass in the data details and the name of the serial port.
-  ET.begin(details(mydata), &mySerial);
+  Wire.begin();
+  //start the library, pass in the data details and the name of the serial port. Can be Serial, Serial1, Serial2, etc.
+  ET.begin(details(mydata), &Wire);
   
   pinMode(13, OUTPUT);
   
@@ -39,7 +33,7 @@ void loop(){
   mydata.blinks = random(5);
   mydata.pause = random(5);
   //send the data
-  ET.sendData();
+  ET.sendData(I2C_SLAVE_ADDRESS);
   
   //Just for fun, we will blink it out too
    for(int i = mydata.blinks; i>0; i--){

--- a/EasyTransferVirtualWire/examples/ETVirtualWireDemoRX/ETVirtualWireDemoRX.pde
+++ b/EasyTransferVirtualWire/examples/ETVirtualWireDemoRX/ETVirtualWireDemoRX.pde
@@ -1,33 +1,34 @@
-#include <SoftEasyTransfer.h>
-
-/*   For Arduino 1.0 and newer, do this:   */
-#include <SoftwareSerial.h>
-SoftwareSerial mySerial(2, 3);
-
-/*   For Arduino 22 and older, do this:   */
-//#include <NewSoftSerial.h>
-//NewSoftSerial mySerial(2, 3);
+#include <VirtualWire.h>
+#include <EasyTransferVirtualWire.h>
 
 
 //create object
-SoftEasyTransfer ET; 
+EasyTransferVirtualWire ET; 
 
-struct RECEIVE_DATA_STRUCTURE{
-  //put your variable definitions here for the data you want to receive
+struct SEND_DATA_STRUCTURE{
+  //put your variable definitions here for the data you want to send
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int blinks;
-  int pause;
+  //Struct can'e be bigger then 26 bytes for VirtualWire version
+  int16_t blinks;
+  int16_t pause;
 };
 
 //give a name to the group of data
-RECEIVE_DATA_STRUCTURE mydata;
+SEND_DATA_STRUCTURE mydata;
 
 void setup(){
-  mySerial.begin(9600);
-  //start the library, pass in the data details and the name of the serial port.
-  ET.begin(details(mydata), &mySerial);
+  //start the library, pass in the data details
+  ET.begin(details(mydata));
+  
+  // Initialise the IO and ISR
+  vw_set_ptt_inverted(true); // Required for DR3100
+  vw_setup(2000);	 // Bits per sec
+
+  vw_rx_start();       // Start the receiver PLL running
   
   pinMode(13, OUTPUT);
+  
+  randomSeed(analogRead(0));
   
 }
 
@@ -43,6 +44,8 @@ void loop(){
       delay(mydata.pause * 100);
     }
   }
+  
   //you should make this delay shorter then your transmit delay or else messages could be lost
   delay(250);
 }
+

--- a/EasyTransferVirtualWire/examples/ETVirtualWireDemoTX/ETVirtualWireDemoTX.pde
+++ b/EasyTransferVirtualWire/examples/ETVirtualWireDemoTX/ETVirtualWireDemoTX.pde
@@ -9,8 +9,8 @@ struct SEND_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to send
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
   //Struct can'e be bigger then 26 bytes for VirtualWire version
-  int blinks;
-  int pause;
+  int16_t blinks;
+  int16_t pause;
 };
 
 //give a name to the group of data

--- a/SoftEasyTransfer/examples/SoftEasyTransfer_RX_Example/SoftEasyTransfer_RX_Example.pde
+++ b/SoftEasyTransfer/examples/SoftEasyTransfer_RX_Example/SoftEasyTransfer_RX_Example.pde
@@ -1,34 +1,33 @@
-#include <VirtualWire.h>
-#include <EasyTransferVirtualWire.h>
+#include <SoftEasyTransfer.h>
+
+/*   For Arduino 1.0 and newer, do this:   */
+#include <SoftwareSerial.h>
+SoftwareSerial mySerial(2, 3);
+
+/*   For Arduino 22 and older, do this:   */
+//#include <NewSoftSerial.h>
+//NewSoftSerial mySerial(2, 3);
 
 
 //create object
-EasyTransferVirtualWire ET; 
+SoftEasyTransfer ET; 
 
-struct SEND_DATA_STRUCTURE{
-  //put your variable definitions here for the data you want to send
+struct RECEIVE_DATA_STRUCTURE{
+  //put your variable definitions here for the data you want to receive
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  //Struct can'e be bigger then 26 bytes for VirtualWire version
-  int blinks;
-  int pause;
+  int16_t blinks;
+  int16_t pause;
 };
 
 //give a name to the group of data
-SEND_DATA_STRUCTURE mydata;
+RECEIVE_DATA_STRUCTURE mydata;
 
 void setup(){
-  //start the library, pass in the data details
-  ET.begin(details(mydata));
-  
-  // Initialise the IO and ISR
-  vw_set_ptt_inverted(true); // Required for DR3100
-  vw_setup(2000);	 // Bits per sec
-
-  vw_rx_start();       // Start the receiver PLL running
+  mySerial.begin(9600);
+  //start the library, pass in the data details and the name of the serial port.
+  ET.begin(details(mydata), &mySerial);
   
   pinMode(13, OUTPUT);
-  
-  randomSeed(analogRead(0));
   
 }
 
@@ -44,8 +43,6 @@ void loop(){
       delay(mydata.pause * 100);
     }
   }
-  
   //you should make this delay shorter then your transmit delay or else messages could be lost
   delay(250);
 }
-

--- a/SoftEasyTransfer/examples/SoftEasyTransfer_TX_Example/SoftEasyTransfer_TX_Example.pde
+++ b/SoftEasyTransfer/examples/SoftEasyTransfer_TX_Example/SoftEasyTransfer_TX_Example.pde
@@ -1,26 +1,32 @@
-#include <Wire.h>
-#include <EasyTransferI2C.h>
+#include <SoftEasyTransfer.h>
+
+/*   For Arduino 1.0 and newer, do this:   */
+#include <SoftwareSerial.h>
+SoftwareSerial mySerial(2, 3);
+
+/*   For Arduino 22 and older, do this:   */
+//#include <NewSoftSerial.h>
+//NewSoftSerial mySerial(2, 3);
+
+
 
 //create object
-EasyTransferI2C ET; 
+SoftEasyTransfer ET; 
 
 struct SEND_DATA_STRUCTURE{
   //put your variable definitions here for the data you want to send
   //THIS MUST BE EXACTLY THE SAME ON THE OTHER ARDUINO
-  int blinks;
-  int pause;
+  int16_t blinks;
+  int16_t pause;
 };
 
 //give a name to the group of data
 SEND_DATA_STRUCTURE mydata;
 
-//define slave i2c address
-#define I2C_SLAVE_ADDRESS 9
-
 void setup(){
-  Wire.begin();
-  //start the library, pass in the data details and the name of the serial port. Can be Serial, Serial1, Serial2, etc.
-  ET.begin(details(mydata), &Wire);
+  mySerial.begin(9600);
+  //start the library, pass in the data details and the name of the serial port.
+  ET.begin(details(mydata), &mySerial);
   
   pinMode(13, OUTPUT);
   
@@ -33,7 +39,7 @@ void loop(){
   mydata.blinks = random(5);
   mydata.pause = random(5);
   //send the data
-  ET.sendData(I2C_SLAVE_ADDRESS);
+  ET.sendData();
   
   //Just for fun, we will blink it out too
    for(int i = mydata.blinks; i>0; i--){


### PR DESCRIPTION
This very simple edit changes "int" to "int16_t" for all the examples.

Several users have [reported](https://forum.pjrc.com/threads/40444-Serial-communication-to-Arduino-boards-not-working?p=125595&viewfull=1#post125595) [problems](https://forum.pjrc.com/threads/36694-Teensy-3-1-to-Arduino-Mega-data-transfer-EasyTransfer?p=116621&viewfull=1#post116621) using EasyTransfer between AVR-based boards like Arduino Nano and 32 bit boards like Teensy or Arduino Zero.  EasyTransfer works great when the structs are perfectly identical.  But since int is 16 bits on AVR and 32 bits on most other boards, the examples fail when people try to use them to communicate between different boards.

This pull request also changes 2 of the examples to use INPUT_PULLUP.  While Teensy and many other boards do emulate the AVR-specific behavior of digitalWrite() to control pullups, some newer boards do not support this.  INPUT_PULLUP is well supported on all boards with all modern versions of Arduino.