### PR TITLE
Initalize RX packet variables to zero

### DIFF
--- a/EasyTransfer/EasyTransfer.cpp
+++ b/EasyTransfer/EasyTransfer.cpp
@@ -5,6 +5,8 @@
 
 //Captures address and size of struct
 void EasyTransfer::begin(uint8_t * ptr, uint8_t length, Stream *theStream){
+	rx_len = 0;
+	rx_array_inx = 0;
 	address = ptr;
 	size = length;
 	_stream = theStream;

--- a/EasyTransferI2C/EasyTransferI2C.cpp
+++ b/EasyTransferI2C/EasyTransferI2C.cpp
@@ -5,6 +5,8 @@
 
 //Captures address and size of struct
 void EasyTransferI2C::begin(uint8_t * ptr, uint8_t length, TwoWire *theSerial){
+	rx_len = 0;
+	rx_array_inx = 0;
 	address = ptr;
 	size = length;
 	_serial = theSerial;

--- a/SoftEasyTransfer/SoftEasyTransfer.cpp
+++ b/SoftEasyTransfer/SoftEasyTransfer.cpp
@@ -6,6 +6,8 @@
 #if ARDUINO > 22
 //Captures address and size of struct
 void SoftEasyTransfer::begin(uint8_t * ptr, uint8_t length, SoftwareSerial *theSerial){
+	rx_len = 0;
+	rx_array_inx = 0;
 	address = ptr;
 	size = length;
 	_serial = theSerial;
@@ -17,6 +19,8 @@ void SoftEasyTransfer::begin(uint8_t * ptr, uint8_t length, SoftwareSerial *theS
 #else
 //Captures address and size of struct
 void SoftEasyTransfer::begin(uint8_t * ptr, uint8_t length, NewSoftSerial *theSerial){
+	rx_len = 0;
+	rx_array_inx = 0;
 	address = ptr;
 	size = length;
 	_serial = theSerial;


### PR DESCRIPTION
This change assigns both [rx_len and rx_array_inx](https://github.com/j54n1n/Arduino-EasyTransfer/blob/6d895e72389cabd52b034a1188e3510c01fee855/EasyTransfer/EasyTransfer.cpp#L8-L9) variables to zero from within the begin method.

This is needed in case the content of the RAM is not cleared by a reset. Such a case would be for example uploading updated code to an Arduino Leonardo type board (with USB bootloader). Otherwise the code used from within the receiveData method would use [these uninitialized](https://github.com/madsci1016/Arduino-EasyTransfer/blob/9941b639e8daf7c235e1edcff691210c40aea392/EasyTransfer/EasyTransfer.cpp#L33) [variables](https://github.com/madsci1016/Arduino-EasyTransfer/blob/9941b639e8daf7c235e1edcff691210c40aea392/EasyTransfer/EasyTransfer.cpp#L57) and could potentially fail to read received data.